### PR TITLE
Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "minireset.css",
+  "version": "0.0.2",
+  "description": "A tiny modern CSS reset",
+  "main": "minireset.css",
+  "keywords": [
+    "css",
+    "reset",
+    "mini"
+  ],
+  "authors": [
+    "Jeremy Thomas <bbxdesign@gmail.com> (http://jgthms.com)"
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "A tiny modern CSS reset",
   "main": "minireset.css",
   "scripts": {
+    "version": "sed -i -- \"s/`git describe --abbrev=0 --tags | sed s/v//`/$npm_package_version/g\" bower.json && git add bower.json",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "npm": ">= 2.13.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've added a `bower.json`.
The b46f231 commit adds a npm script to automitize version bump in `bower.jon` file using `npm version [patch|minor|major]`.
It seems you bumpded version manually in `package.json`, using  `npm version` would have added a git tag `v0.0.2`.
If you want the npm script to work properly, you must add `git tag v0.0.2` before trying to bump version with  `npm version ...`

This PR fix #1

