### PR TITLE
Replace RawGit link with jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or clone the repo.
 
 ## CDN
 
-[GitHub CDN for minireset.min.css](https://cdn.rawgit.com/jgthms/minireset.css/master/minireset.min.css)
+[GitHub CDN for minireset.min.css](https://cdn.jsdelivr.net/gh/jgthms/minireset.css@master/minireset.min.css)
 
 ## Copyright and license
 


### PR DESCRIPTION
Since [RawGit "has reached the end of its useful life"](https://rawgit.com/), the link should better lead to jsDelivr, an analogous service (recommended by RawGit's Ryan Grove himself).