### PR TITLE
chore(README.md): change the spelling of minireet.css to minireset.css in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or clone the repo.
 It will be available in your modules directory in `/node_modules/minireset.css/`:
 * `minireset.css`: CSS rules
 * `minireset.min.css`: minified CSS rules (recommended for production sites)
-* `minireet.sass`: CSS rules written in SASS (recommended for SCSS/SASS projects)
+* `minireset.sass`: CSS rules written in SASS (recommended for SCSS/SASS projects)
 * `minireset.css.lit.js`: CSS rules exported as a `CSSResult` object for [LitElement](https://lit-element.polymer-project.org/) projects (recommended for Web Component projects based on LitElement)
 
 ## CDN


### PR DESCRIPTION
This is just a fixup of the README to Close #46 